### PR TITLE
Fix github stats not rendering if they had a value of zero

### DIFF
--- a/app/src/widgets/github-stats/index.tsx
+++ b/app/src/widgets/github-stats/index.tsx
@@ -48,35 +48,35 @@ const GithubStats: React.FC<Props> = ({
 
   return (
     <div>
-      {!!stars && (
+      {typeof stars === 'number' && (
         <StatsRow
           icon="star"
           value={stars}
           labelKey="widget.github-stats.stars"
         />
       )}
-      {!!followers && (
+      {typeof followers === 'number' && (
         <StatsRow
           icon="userFriends"
           value={followers}
           labelKey="widget.github-stats.followers"
         />
       )}
-      {!!subscribers && (
+      {typeof subscribers === 'number' && (
         <StatsRow
           icon="userFriends"
           value={subscribers}
           labelKey="widget.github-stats.subscribers"
         />
       )}
-      {!!forks && (
+      {typeof forks === 'number' && (
         <StatsRow
           icon="codeBranch"
           value={forks}
           labelKey="widget.github-stats.forks"
         />
       )}
-      {!!open_issues && (
+      {typeof open_issues === 'number' && (
         <StatsRow
           icon="error"
           value={open_issues}

--- a/app/src/widgets/github-stats/index.tsx
+++ b/app/src/widgets/github-stats/index.tsx
@@ -48,35 +48,35 @@ const GithubStats: React.FC<Props> = ({
 
   return (
     <div>
-      {typeof stars === 'number' && (
+      {typeof stars === "number" && (
         <StatsRow
           icon="star"
           value={stars}
           labelKey="widget.github-stats.stars"
         />
       )}
-      {typeof followers === 'number' && (
+      {typeof followers === "number" && (
         <StatsRow
           icon="userFriends"
           value={followers}
           labelKey="widget.github-stats.followers"
         />
       )}
-      {typeof subscribers === 'number' && (
+      {typeof subscribers === "number" && (
         <StatsRow
           icon="userFriends"
           value={subscribers}
           labelKey="widget.github-stats.subscribers"
         />
       )}
-      {typeof forks === 'number' && (
+      {typeof forks === "number" && (
         <StatsRow
           icon="codeBranch"
           value={forks}
           labelKey="widget.github-stats.forks"
         />
       )}
-      {typeof open_issues === 'number' && (
+      {typeof open_issues === "number" && (
         <StatsRow
           icon="error"
           value={open_issues}


### PR DESCRIPTION
This PR changes the github-stats widget so that the stats are rendered when they have a number value, instead of when they have a truthy value.

Fixes: #15 