### PR TITLE
Add Dodgecoin as a cryptocurrencies

### DIFF
--- a/app/src/common/translations/en.json
+++ b/app/src/common/translations/en.json
@@ -87,6 +87,7 @@
         "bitcoin": "Bitcoin (BTC)",
         "bitcoin-cash": "Bitcoin Cash (BCH)",
         "dash": "Dash (DASH)",
+        "dogecoin": "Dogecoin (DOGE)",
         "eos": "EOS",
         "ethereum": "Ethereum (ETH)",
         "link": "LINK",

--- a/app/src/widgets/cryptocurrencies/configuration.tsx
+++ b/app/src/widgets/cryptocurrencies/configuration.tsx
@@ -73,6 +73,7 @@ const Configuration = ({ options, setOptions }: ConfigurationProps<Props>) => {
           "bitcoin",
           "bitcoin-cash",
           "dash",
+          "dogecoin",
           "eos",
           "ethereum",
           "link",

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -4,7 +4,8 @@
 
 - :sparkles: Make background image configurable.
 - :rocket: Display widget resize handle when focused.
-- :rocket: Add Nano cryptocurrency.
+- :rocket: Add Nano cryptocurrency
+- :rocket: Add Dogecoin cryptocurrency.
 - :bug: Make widgets configurable on mobile again.
 - :bug: Recalculate grid width on toggling the widget drawer.
 - :hammer: Update dependencies.


### PR DESCRIPTION
Ref: https://www.coingecko.com/en/coins/dogecoin

This adds Dodgecoin as an option in the cryptocurrency widget.